### PR TITLE
AMT diag

### DIFF
--- a/Woche9/README.md
+++ b/Woche9/README.md
@@ -1,4 +1,0 @@
-TODO List:
-1. Finish the AudioMessageTest (9.3e)
-2. Check if ClientTest and ServerTest are valid (9.3e)
-3. Server Class: All to-be-implemented methods should be private??? (9.3d) 

--- a/Woche9/WasGehtApp/tests/AudioMessageTest.java
+++ b/Woche9/WasGehtApp/tests/AudioMessageTest.java
@@ -22,17 +22,17 @@ public class AudioMessageTest {
 
     @Test
     public void getTransferRepresentation() {
-        assertEquals("data.Audio " + null + " " + data, audioMessage.getTransferRepresentation());
+        assertEquals("data.Audio " + "Unavailable Media Info" + " " + data, audioMessage.getTransferRepresentation());
     }
 
     @Test
     public void prettyPrint() {
-        assertEquals("data.Audio " + null + " " + data + " " + "Here's to Adam.", audioMessage.prettyPrint());
+        assertEquals("data.Audio " + "Unavailable Media Info" + " " + data + " " + "Here's to Adam.", audioMessage.prettyPrint());
     }
 
     @Test
     public void getMediaInfo() {
-        assertNull(audioMessage.getMediaInfo());
+        assertEquals("Unavailable Media Info",audioMessage.getMediaInfo());
     }
 
     @Test


### PR DESCRIPTION
@krieger1512 see [here](https://github.com/Paralian/OOP/blob/KIEN/Woche9/WasGehtApp/message/AbstractDataMessage.java#L40). Media Info is never set to `null` by default but rather the specified string from the abstract class